### PR TITLE
add org-mode file mirroring links in README.md

### DIFF
--- a/cs-video-courses.org
+++ b/cs-video-courses.org
@@ -1,0 +1,397 @@
+#+TITLE: Computer Science Lectures with Videos
+#+CATEGORY: cs
+
+* Computer Science video courses
+** Introduction
+
+List of Computer Science courses with video lectures.
+
+-  Please note:
+
+   -  Focus would be to keep the list to the point so that it is
+      readable and usable. To access syllabus/notes/assignments, please
+      visit link to the course or use Google search with course
+      number/name.
+   -  Only MOOCs with comprehensive lecture material which may be
+      equivalent to a standard University course will be added.
+   -  [[http://nptel.ac.in/][NPTEL]] contains large number of good
+      Computer Science courses. To check courses by Indian IIT's, please
+      refer nptel site.
+
+--------------
+
+** Table of Contents
+ -  [[#introduction-to-computer-science][Introduction to Computer Science]]
+ -  [[#data-structures-and-algorithms][Data Structures and Algorithms]]
+ -  [[#systems-programming][Systems Programming]]
+ -  [[#distributed-systems][Distributed Systems]]
+ -  [[#database-systems][Database Systems]]
+ -  [[#object-oriented-design-and-software-engineering][Object Oriented Design and Software Engineering]]
+ -  [[#artificial-intelligence][Artificial Intelligence]]
+ -  [[#machine-learning][Machine Learning]]
+ -  [[#web-programming-and-internet-technologies][Web Programming and Internet Technologies]]
+ -  [[#concurrency][Concurrency]]
+ -  [[#computer-networks][Computer Networks]]
+ -  [[#mobile-applications-development][Mobile Applications Development]]
+ -  [[#math-for-computer-scientist][Math for Computer Scientist]]
+ -  [[#theoretical-cs-and-programming-languages][Theoretical CS and Programming Languages]]
+ -  [[#computer-organization-and-architecture][Computer Organization and Architecture]]
+ -  [[#security][Security]]
+ -  [[#computer-graphics][Computer Graphics]]
+ -  [[#image-processing-and-computer-vision][Image Processing and Computer Vision]]
+ -  [[#hci][HCI]]
+ -  [[#computational-biology][Computational Biology]]
+ -  [[#misc][Misc]]
+
+** Courses
+*** Introduction to Computer Science [0/14]
+  - [ ] [[https://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-00sc-introduction-to-computer-science-and-programming-spring-2011/][6.00SC - Introduction to Computer Science and Programming (Spring 2011) - MIT OCW]]
+  - [ ] [[https://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-00-introduction-to-computer-science-and-programming-fall-2008/video-lectures/][6.00 - Introduction to Computer Science and Programming (Fall 2008) - MIT OCW]]
+  - [ ] [[https://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-01sc-introduction-to-electrical-engineering-and-computer-science-i-spring-2011/][6.01SC - Introduction to Electrical Engineering and Computer Science I - MIT OCW]]
+  - [ ] [[http://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-001-structure-and-interpretation-of-computer-programs-spring-2005/video-lectures][6.001 - Structure and Interpretation of Computer Programs, MIT]] ([[http://mitpress.mit.edu/sicp/full-text/book/book.html][Textbook]])
+  - [ ] [[https://www.youtube.com/playlist?list=PL-XXv-cvA_iC17q7Pydw_RernkItDJePz][CS 10 The Beauty & Joy of Computing, Spring 2015 - UCBerkeley]]
+  - [ ] [[https://cs50.harvard.edu/lectures][CS 50 - Introduction to Computer Science, Harvard University]] ([[http://cs50.tv/2015/fall/][cs50.tv]])
+  - [ ] [[http://cs61a.org/][61A - Structure and Interpretation of Computer Programs (Python, UC Berkeley)]]
+  - [ ] [[http://online.stanford.edu/course/computer-science-101-self-paced][C 101 - Computer Science 101, Stanford University]] (Register free to access Videos)
+  - [ ] [[http://cse1.net/lectures][CS E-1 Understanding Computers and the Internet, Spring 2013 - Harvard Extension School]] ([[http://computerscience1.tv/2011/spring/][Spring 2011]])
+  - [ ] [[https://courses.cs.washington.edu/courses/cse142-TVI/00au/lectures/][CSE 142 Computer Programming I (C Programming), Autumn 200 - University of Washington]]
+  - [ ] [[http://www.cc.gatech.edu/classes/AY2016/cs1301c_fall/][CS1301 Intro to computing - Gatech]]
+  - [ ] [[http://see.stanford.edu/see/lecturelist.aspx?coll=824a47e1-135f-4508-a5aa-866adcae1111][CS 106A - Programming Methodology, Stanford University]]
+  - [ ] [[http://see.stanford.edu/see/lecturelist.aspx?coll=11f4f422-5670-4b4c-889c-008262e09e4e][CS 106B - Programming Abstractions, Stanford University]]
+  - [ ] [[http://see.stanford.edu/see/lecturelist.aspx?coll=2d712634-2bf1-4b55-9a3a-ca9d470755ee][CS 107 - Programming Paradigms, Stanford University]]
+
+--------------
+
+*** Data Structures and Algorithms [0/31]
+- [ ] [[https://people.eecs.berkeley.edu/~jrs/61b/][CS 61B - Data Structures, UC Berkeley]]
+  - [ ] [[https://www.youtube.com/playlist?list=PL4BBB74C7D2A1049C][Fall 2006 - Prof. Jonathan Shewchuk]]
+  - [ ] [[http://datastructur.es/sp16/][Spring 16 - Josh Hug]]
+- [ ] [[https://www.youtube.com/playlist?list=PLLH73N9cB21W1TZ6zz1dLkyIm50HylGyg][MOOC - Design and Analysis of Algorithms Part 1 - Prof Roughgarden - Coursera]] ([[https://www.youtube.com/playlist?list=PLLH73N9cB21VPj3H2xwTTye5TC8-UniA2][Part 2]])
+- [ ] [[https://www.youtube.com/playlist?list=PLUX6FBiUa2g4YWs6HkkCpXL6ru02i7y3Q][MOOC - Algorithms Part 1 - Prof Sedgewick]] ([[https://www.youtube.com/playlist?list=PLqD_OdMOd_6YixsHkd9f4sNdof4IhIima][Part 2]])
+- [ ] [[http://www.cise.ufl.edu/~sahni/cop3530/][COP 3530 Data Structures and Algorithms, Prof Sahni, UFL]] ([[http://www.cise.ufl.edu/academics/courses/preview/cop3530sahni/][Videos]])
+- [ ] [[https://www.youtube.com/playlist?list=PLE621E25B3BF8B9D1][CS2: Data Structures and Algorithms - Richard Buckland - UNSW]]
+- [ ] [[http://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-006-introduction-to-algorithms-fall-2011/lecture-videos/][6.006 - Introduction to Algorithms, MIT OCW]]
+- [ ] [[http://openclassroom.stanford.edu/MainFolder/CoursePage.php?course=IntroToAlgorithms][CS 161 - Design and Analysis of Algorithms, Prof. Tim Roughgarden, Stanford University]]
+- [ ] [[http://www.cs.sunysb.edu/~algorith/video-lectures/][CSE 373 - Analysis of Algorithms, Stony Brook - Prof Skiena]]
+- [ ] [[http://cs.brown.edu/courses/csci0160/lectures.html][CS16 Introduction to Algorithms and Data Structures - Brown University]]
+- [ ] [[https://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-046j-introduction-to-algorithms-sma-5503-fall-2005/video-lectures/][6.046J - Introduction to Algorithms - Fall 2005, MIT OCW]]
+- [ ] [[https://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-046j-design-and-analysis-of-algorithms-spring-2015/lecture-videos/][6.046 - Design and Analysis of Algorithms, Spring 2015 - MIT OCW]]
+- [ ] [[https://courses.engr.illinois.edu/cs473/sp2016/lectures.html][CS 473: Algorithms - University of Illinois at Urbana-Champaign]]
+- [ ] [[http://www.algorist.com/programming_challenges/][Programming Challenges - Prof Skiena]]
+- [ ] [[http://www.cs.virginia.edu/~shelat/16s-4102/][16s-4102 - Algorithms, University of Virginia]] ([[https://www.youtube.com/channel/UCxXYk53cSZof2bR_Ax0uJYQ/videos][Youtube]])
+- [ ] [[https://www.youtube.com/playlist?list=PL-XXv-cvA_iDbtIylJDpPPJfaFweeaR-3][CS 170 Algorithms - Spring 2015 - UCBerkeley]]
+- [ ] [[http://www.cise.ufl.edu/~sahni/cop5536/index.html][COP 5536 Advanced Data Structures, Prof Sahni - UFL]] ([[http://www.cise.ufl.edu/academics/courses/preview/cop5536sahni/][Videos]])
+- [ ] [[http://theory.stanford.edu/~tim/w16/w16.html][CS 261 - A Second Course in Algorithms, Stanford University]] ([[http://theory.stanford.edu/~tim/w16/w16.html][Lectures]]) ([[https://www.youtube.com/playlist?list=PLEGCF-WLh2RJh2yDxlJJjnKswWdoO8gAc][Youtube]])
+- [ ] [[http://people.seas.harvard.edu/~minilek/cs224/fall14/index.html][CS 224 - Advanced Algorithms, Harvard University]] ([[http://people.seas.harvard.edu/~minilek/cs224/fall14/lec.html][Lecture Videos]]) ([[https://www.youtube.com/playlist?list=PL2SOU6wwxB0uP4rJgf5ayhHWgw7akUWSf][Youtube]])
+- [ ] [[http://web.cs.ucdavis.edu/~gusfield/cs122f10/videolist.html][ECS 122A - Algorithm Design and Analysis, UC Davis]]
+- [ ] [[http://courses.cs.washington.edu/courses/csep521/13wi/][CSEP 521: Applied Algorithms, Winter 2013 - University of Washington]] ([[http://courses.cs.washington.edu/courses/csep521/13wi/video/][Videos]])
+- [ ] [[https://www.youtube.com/playlist?list=PLbuogVdPnkCp8X9FHOglnLqFjyvqGLftx][CS 6150 - Advanced Algorithms (Fall 2016), University of Utah]]
+- [ ] [[http://web.cs.ucdavis.edu/~gusfield/cs222f07/videolist.html][ECS 222A - Graduate Level Algorithm Design and Analysis, UC Davis]]
+- [ ] [[http://courses.csail.mit.edu/6.851/spring14/lectures/][6.851 - Advanced Data Structures, MIT]] ([[https://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-851-advanced-data-structures-spring-2012/lecture-videos/][MIT OCW]])
+- [ ] [[https://www.youtube.com/playlist?list=PL6ogFv-ieghdoGKGg2Bik3Gl1glBTEu8c][6.854 - Advanced Algorithms, MIT]] ([[https://www.youtube.com/channel/UCtv9PiQVUDzsT4yl7524DCg/videos][Prof. Karger lectures]])
+- [ ] [[http://theory.stanford.edu/~tim/f14/f14.html][CS264 Beyond Worst-Case Analysis, Fall 2014 - Tim Roughgarden Lecture]] ([[https://www.youtube.com/playlist?list=PLEGCF-WLh2RL8jsZpaf2tLHa5LotFEt5b][Youtube]])
+- [ ] [[https://www.youtube.com/playlist?list=PLEGCF-WLh2RJBqmxvZ0_ie-mleCFhi2N4][CS364A Algorithmic Game Theory, Fall 2013 - Tim Roughgarden Lectures]]
+- [ ] [[https://www.youtube.com/playlist?list=PLEGCF-WLh2RI77PL4gwLld_OU9Zh3TCX9][CS364B Advanced Mechanism Design, Winter 2014 - Tim Roughgarden Lectures]]
+- [ ] [[http://aduni.org/courses/algorithms/index.php?view=cw][Algorithms - Aduni]]
+- [ ] [[https://electures.informatik.uni-freiburg.de/portal/web/guest/detail/-/modulnavigation/view/4/252/][Advanced Topics in Algorithms and Datastructures - SS 2005 - Universität Freiburg]]
+- [ ] [[https://electures.informatik.uni-freiburg.de/portal/web/guest/detail/-/modulnavigation/view/5402/16009/][Algorithmentheorie/Algorithms Theory - WS 2013 - Universität Freiburg]] ([[https://electures.informatik.uni-freiburg.de/portal/web/guest/detail/-/modulnavigation/view/4003/12514/][WS 2011]])
+- [ ] [[https://electures.informatik.uni-freiburg.de/portal/web/guest/detail/-/modulnavigation/view/2103/8701/][Theory I - SS 2010 - Universität Freiburg]]
+
+--------------
+
+*** Systems Programming [0/22]
+  - [ ] [[https://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-033-computer-system-engineering-spring-2009/video-lectures/][6.033 Computer System Engineering - MIT]]
+  - [ ] [[http://courses.cms.caltech.edu/cs24/][CS24 Introduction to Computing Systems - California Institute of Technology]] ([[http://users.cms.caltech.edu/~donnie/cs24/][Spring 15 version]])
+  - [ ] [[https://scs.hosted.panopto.com/Panopto/Pages/Sessions/List.aspx#folderID=%22b96d90ae-9871-4fae-91e2-b1627b43e25e%22&maxResults=150][15-213 Introduction to Computer Systems, Fall 2015 - CMU]]
+  - [ ] [[https://www.cs.uic.edu/CS361fall13][CS361 - COMPUTER SYSTEMS - UIC]]
+  - [ ] [[http://users.cms.caltech.edu/~donnie/cs124/][CS124 Operating Systems - California Institute of Technology]]
+  - [ ] [[http://aduni.org/courses/systems/index.php?view=cw][Systems - Aduni]]
+  - [ ] [[http://cs162.eecs.berkeley.edu/][CS 162 - Operating Systems and Systems Programming, UC Berkeley]] ([[https://www.youtube.com/playlist?list=PL-XXv-cvA_iBDyz-ba4yDskqMDY6A1w_c][Lectures - YouTube]])
+  - [ ] [[http://rust-class.org/pages/classes.html][CS 4414 - Operating Systems, University of Virginia]]
+  - [ ] [[https://www.ops-class.org/courses/buffalo/CSE421_Spring2016/][CSE 421/521 - Introduction to Operating Systems, SUNY University at Buffalo, NY - Spring 2016]] ([[https://www.youtube.com/playlist?list=PLE6LEE8y2Jp-kbEcVR2W3vfx0Pdca0BD3][Lectures - YouTube]])
+  - [ ] [[https://www.youtube.com/playlist?list=PLacuG5pysFbDTmsCRGWsMW_PzIOpXnckw][CS 377 Fall 16: Operating Systems - Umass OS]]
+  - [ ] [[https://www.youtube.com/playlist?list=PLfciLKR3SgqNJKKIKUliWoNBBH1VHL3AP][6.828: Operating System Engineering (Fall 2014]])
+  - [ ] [[http://courses.cs.washington.edu/courses/csep551/14au/video/][CSEP 551 Operating Systems Autumn 2014 - University of Washington]]
+  - [ ] [[https://www.youtube.com/playlist?list=PL-XXv-cvA_iB_5Q8G8kW5idSwNmXypmQE][CS194 Advanced Operating Systems Structures and Implementation, Spring 2013, UC Berkeley]]
+  - [ ] [[http://faculty.cs.tamu.edu/bettati/Courses/663/Video/presentation.html][CPCS 663 - Real-Time Systems: Video Material - TAMU]]
+  - [ ] [[https://www.youtube.com/playlist?list=PLZ9NgFYEMxp4ZsvD10uXmClGnukcu3Uff][CS 251: Intermediate Software Design (C++ version)]]
+  - [ ] [[https://www.youtube.com/playlist?list=PLZ9NgFYEMxp7lylj-XC8h1kjatOjbh9ne][CS 251 (2015): Intermediate Software Design]]
+  - [ ] [[https://www.youtube.com/view_play_list?p=AB7D5CA7E262B0E2][CSE 30341 - Spr 2008: Operating Systems]]
+  - [ ] [[https://www.youtube.com/view_play_list?p=22B10D854588E20C][CSE 60641 - Fall 08: Graduate Operating Systems]]
+  - [ ] [[https://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-172-performance-engineering-of-software-systems-fall-2010/][6.172 Performance Engineering of Software Systems - MIT OCW]]
+  - [ ] [[https://itunes.apple.com/us/itunes-u/software-engineering-for-self/id993578475][Software Engineering for Self Adaptive Systems - iTunes - HPI]]
+  - [ ] [[https://electures.informatik.uni-freiburg.de/portal/web/guest/detail/-/modulnavigation/view/5201/15648/][Real-Time Systems - SS 2013 - Universität Freiburg]]
+  - [ ] [[https://electures.informatik.uni-freiburg.de/portal/web/guest/detail/-/modulnavigation/view/4808/14532/][System Infrastructure For Data Science - WS 2012 - Universität Freiburg]]
+
+--------------
+
+*** Distributed Systems [0/9]
+  - [ ] [[http://www.distributed-systems.net/courses/ds/ds-screencasts/][VU:Distributed Systems: Principles and Paradigms by Maarten van Steen (Fall 2012), Vrije Universiteit, Amsterdam]]
+  - [ ] [[https://www.youtube.com/playlist?list=PLacuG5pysFbC68w0PW3huMHDDRNsDCTjp][CS 677 Spring 16: Distributed Operating Systems - Umass OS]]
+  - [ ] [[https://www.youtube.com/playlist?list=PLawkBQ15NDEkDJ5IyLIJUTZ1rRM9YQq6N][CS 436: Distributed Computer Systems - U Waterloo]]
+  - [ ] [[https://www.youtube.com/playlist?list=PLkcQbKbegkMqiWf7nF8apfMRL4P4sw8UL][6.824: Distributed Systems, Spring 2015 - MIT]]
+  - [ ] [[https://www.youtube.com/playlist?list=PL700757A5D4B3F368][Distributed Algorithms, https://canvas.instructure.com/courses/902299]]
+  - [ ] [[http://cs.brown.edu/courses/csci1380/s16/syllabus.html][CS138 Distributed Computer Systems Spring 2016 - Brown University]]
+  - [ ] [[http://courses.cs.washington.edu/courses/csep552/13sp/][CSEP 552: PMP Distributed Systems, Spring 2013 - University of Washington]] ([[http://courses.cs.washington.edu/courses/csep552/13sp/video/][Videos]])
+  - [ ] [[http://courses.cs.washington.edu/courses/cse490h/08au/lectures.htm][CSE 490H: Scalable Systems: Design, Implementation and Use of Large Scale Clusters, Autumn 2008 - University of Washington]] ([[http://courses.cs.washington.edu/courses/cse490h/08au/video.htm][Videos]])
+  - [ ] [[https://www.youtube.com/playlist?list=PLFd87qVsaLhOkTLvfp6MC94iFa_1c9wrU][MOOC - Cloud Computing Concepts - UIUC]]
+
+--------------
+
+*** Database Systems [0/12]
+  - [ ] [[http://users.cms.caltech.edu/~donnie/cs121/][CS121 - Introduction to Relational Database Systems, Fall 2016 - Caltech]]
+  - [ ] [[http://users.cms.caltech.edu/~donnie/cs122/][CS122 - Relational Database System Implementation, Winter 2014-2015 - Caltech]]
+  - [ ] [[https://www.youtube.com/playlist?list=PLbuogVdPnkCrercQNP9tTsjjPdgRVYvC7][CS 5530 - Database Systems, Spring 2016, University of Utah]]
+  - [ ] [[https://www.youtube.com/playlist?list=PL6hGtHedy2Z4EkgY76QOcueU8lAC4o6c3][MOOC - Database Stanford Dbclass]]
+  - [ ] [[https://www.youtube.com/playlist?list=PLTPQEx-31JXjQYrUKvAjUTWgCYluHGs_L][CSEP 544, Database Management Systems, Au 2015 - University of Washington]]
+  - [ ] [[http://www.cse.psu.edu/~yul189/cmpsc431w/lectures.html][CMPSC 431W Database Management Systems, Fall 2015 - PSU]]
+  - [ ] [[https://www.youtube.com/playlist?list=PLdQddgMBv5zEhlpqdiUcf9aTNEtmESgyl][Principles of Database Management, Bart Baesens]]
+  - [ ] [[http://15721.courses.cs.cmu.edu/spring2016/][15-721 - Database Systems, CMU]] ([[https://www.youtube.com/playlist?list=PLSE8ODhjZXjbisIGOepfnlbfxeH7TW-8O][Lectures - YouTube]])
+  - [ ] [[https://sites.google.com/site/cs186spring2015/home/schedule-and-notes][CS 186 - Database Systems, UC Berkeley, Spring 2015]] ([[https://www.youtube.com/playlist?list=PL-XXv-cvA_iBVK2QzAV-R7NMA1ZkaiR2y][Lectures-YouTube]])
+  - [ ] [[https://www.cs.utah.edu/~lifeifei/cs6530/][CS 6530 - Graduate-level Database Systems, Fall 2016, University of Utah]] ([[https://www.youtube.com/playlist?list=PLbuogVdPnkCqwHUcieMrytP453Ep0y6eI][Lectures - YouTube]])
+  - [ ] [[https://www.youtube.com/playlist?list=PLfciLKR3SgqOxCy1TIXXyfTqKzX2enDjK][6.830/6.814: Database Systems (Fall 2014]])
+  - [ ] [[https://itunes.apple.com/us/podcast/fit9003-database-systems-design/id306569364?ign-mpt=uo%3D8][FIT9003 Database Systems Design, Rob Meredith, Monash University]]
+
+--------------
+
+*** Object Oriented Design and Software Engineering [0/10]
+  - [ ] [[https://engineering.purdue.edu/OOSD/F2008/F2008.html][ECE 462 Object-Oriented Programming using C++ and Java - Purdue]]
+  - [ ] [[http://aduni.org/courses/java/index.php?view=cw][Object-oriented Program Design and Software Engineering - Aduni]]
+  - [ ] [[https://www.youtube.com/playlist?list=PL6XklZATqYx9dj72MKG6wLYjljeB2odra][Object Oriented Systems Analysis and Design (Systems Analysis and Design in a Changing World)]]
+  - [ ] [[https://www.youtube.com/playlist?list=PL-XXv-cvA_iCfQHHS7rxlfHFsU4aQW1IF][Computer Science 169- Software Engineering - Spring 2015 - UCBerkeley]]
+  - [ ] [[https://www.youtube.com/playlist?list=PLBdajHWwi0JCn87QuFT3e58mekU0-6WUT][Introduction to Service Design and Engineering - University of Trento, Italy]]
+  - [ ] [[https://www.youtube.com/playlist?list=PLJ9pm_Rc9HesnkwKlal_buSIHA-jTZMpO][OOSE: Software Dev Using UML and Java]]
+  - [ ] [[http://video.bilkent.edu.tr/course_videos.php?courseid=10][CS 411 - Software Architecture Design, Bilkent University]]
+  - [ ] [[http://cs164.tv/2014/spring/][CS 164 Software Engineering - Harvard]]
+  - [ ] [[https://electures.informatik.uni-freiburg.de/portal/web/guest/detail/-/modulnavigation/view/83/3022/][Model Driven Archtitecture - WS 2005 - Universität Freiburg]]
+  - [ ] [[https://electures.informatik.uni-freiburg.de/portal/web/guest/detail/-/modulnavigation/view/5405/16022/][Software Design, Modelling and Analysis in UML - WS 2012 - Universität Freiburg]]
+
+--------------
+
+*** Artificial Intelligence [0/5]
+  - [ ] [[http://ai.berkeley.edu/home.html][CS 188 - Introduction to Artificial Intelligence, UC Berkeley]]
+  - [ ] [[https://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-034-artificial-intelligence-fall-2010/lecture-videos/][6.034 Artificial Intelligence, MIT OCW]]
+  - [ ] [[http://www.cs.cmu.edu/~zkolter/course/15-780-s14/lectures.html][15-780: Graduate Artificial Intelligence, Spring 14, CMU]]
+  - [ ] [[http://courses.cs.washington.edu/courses/csep573/03wi/lectures/index.htm][CSE 592 Applications of Artificial Intelligence, Winter 2003 - University of Washington]]
+  - [ ] [[https://electures.informatik.uni-freiburg.de/portal/web/guest/detail/-/modulnavigation/view/1/349/][Advanced AI Techniques - WS 2005 - Universität Freiburg]] ([[https://electures.informatik.uni-freiburg.de/portal/web/guest/detail/-/modulnavigation/view/2/335/][WS 2004]])
+
+--------------
+
+*** Machine Learning [0/6]
+  - [ ] *Introduction to Machine Learning* [0/15]
+    - [ ] [[https://www.youtube.com/playlist?list=PLJ1-ciQ35nuiyL1PX6O4NdF5CjjaDdnVC][MOOC Machine Learning Andrew Ng - Coursera/Stanford]] ([[http://www.holehouse.org/mlclass/][Notes]])
+    - [ ] [[https://lagunita.stanford.edu/courses/HumanitiesandScience/StatLearning/Winter2015/about][MOOC - Statistical Learning, Stanford University]]
+    - [ ] [[https://work.caltech.edu/lectures.html][CS 156 - Learning from Data, Caltech]]
+    - [ ] [[http://www.cs.cmu.edu/~ninamf/courses/601sp15/lectures.shtml][10-601 - Introduction to Machine Learning (MS), Carnegie Mellon University]]
+    - [ ] [[http://www.cs.cmu.edu/~tom/10701_sp11/lectures.shtml][10-701 - Introduction to Machine Learning (PhD) - Tom Mitchell, Spring 2011, Carnegie Mellon University]] ([[https://www.youtube.com/playlist?list=PL7y-1rk2cCsDZCVz2xS7LrExqidHpJM3B][Fall 2014]])
+    - [ ] [[https://www.youtube.com/playlist?list=PL34iyE0uXtxo7vPXGFkmm6KbgZQwjf9Kf][Microsoft Research - Machine Learning Course]]
+    - [ ] [[http://l2r.cs.illinois.edu/~danr/Teaching/CS446-16/schedule.html][CS 446 - Machine Learning, Fall 2016, UIUC]]([[https://www.youtube.com/playlist?list=PLQcasX5-oG91n10wPxeRh-45-8HATwc8W][Fall 2015 Lectures]])
+    - [ ] [[https://www.youtube.com/playlist?list=PLE6Wd9FR--Ecf_5nCbnSQMHqORpiChfJf][undergraduate machine learning at UBC 2012, Nando de Freitas]]
+    - [ ] [[https://www.youtube.com/playlist?list=PLA89DCFA6ADACE599][CS 229 - Machine Learning - Stanford University]]
+    - [ ] [[https://people.eecs.berkeley.edu/~jrs/189/][CS 189/289A Introduction to Machine Learning, Prof Jonathan Shewchuk - UCBerkeley]]
+    - [ ] [[https://www.youtube.com/playlist?list=PLbuogVdPnkCozRSsdueVwX7CF9N4QWL0B][CS 5350/6350 - Machine Learning, Fall 2016, University of Utah]]
+    - [ ] [[https://filebox.ece.vt.edu/~s15ece5984/][ECE 5984 Introduction to Machine Learning, Spring 2015 - Virginia Tech]]
+    - [ ] [[http://www.cs.toronto.edu/~rsalakhu/STA4273_2015/lectures.html][STA 4273H (Winter 2015): Large Scale Machine Learning]]
+    - [ ] [[https://www.youtube.com/channel/UCR4_akQ1HYMUcDszPQ6jh8Q/videos][CS 485/685 Machine Learning, Shai Ben-David, University of Waterloo]]
+    - [ ] [[https://electures.informatik.uni-freiburg.de/portal/web/guest/detail/-/modulnavigation/view/75/3164/][Machine Learning and Data Mining - WS 2004 - Universität Freiburg]]
+  - [ ] *Data Mining* [0/8]
+    - [ ] [[https://courses.cs.washington.edu/courses/csep546/16sp/][CSEP 546, Data Mining - Pedro Domingos, Sp 2016 - University of Washington]] ([[https://www.youtube.com/playlist?list=PLTPQEx-31JXgtDaC6-3HxWcp7fq4N8YGr][YouTube]])
+    - [ ] [[https://www.cs.utah.edu/~jeffp/teaching/cs5140.html][CS 5140/6140 - Data Mining, Spring 2016, University of Utah]] ([[https://www.youtube.com/playlist?list=PLbuogVdPnkCpXfb43Wvc7s5fXWzedwTPB][Youtube]])
+    - [ ] [[http://www.cs.utah.edu/~jeffp/teaching/cs5955.html][CS 5955/6955 - Data Mining, University of Utah]] ([[https://www.youtube.com/channel/UCcrlwW88yMcXujhGjSP2WBg/videos][YouTube]])
+    - [ ] [[https://www.youtube.com/playlist?list=PLFE776F2C513A744E][Statistical Aspects of Data Mining (Stats 202) - Google]]
+    - [ ] [[https://www.youtube.com/playlist?list=PLLssT5z_DsK8Xwnh_0bjN4KNT81bekvtt][MOOC - Text Mining and Analytics by ChengXiang Zhai]]
+    - [ ] [[https://itunes.apple.com/us/itunes-u/information-retrieval-ss-2014/id874200291][Information Retrieval SS 2014, iTunes - HPI]]
+    - [ ] [[https://www.youtube.com/playlist?list=PLm4W7_iX_v4NqPUjceOGd-OKNVO4c_cPD][MOOC - Data Mining with Weka]]
+    - [ ] [[https://www.youtube.com/playlist?list=PLB4CCA346A5741C4C][CS 290 DataMining Lectures]]
+  - [ ] *Probabilistic Graphical Modeling* [0/3]
+    - [ ] [[https://www.youtube.com/playlist?list=PLbuogVdPnkCpvxdF-Gy3gwaBObx7AnQut][CS 6190 - Probabilistic Modeling, Spring 2016, University of Utah]]
+    - [ ] [[http://www.cs.cmu.edu/~epxing/Class/10708-14/lecture.html][10-708 - Probabilistic Graphical Models, Carnegie Mellon University]]
+    - [ ] [[http://openclassroom.stanford.edu/MainFolder/CoursePage.php?course=ProbabilisticGraphicalModels][Probabilistic Graphical Models, Daphne Koller, Stanford University]]
+  - [ ] *Deep Learning* [0/4]
+    - [ ] [[https://www.youtube.com/playlist?list=PLE6Wd9FR--EfW8dtjAuPoTuPcqmOV53Fu][Deep learning at Oxford 2015 - Nando de Freitas]]
+    - [ ] [[http://cilvr.cs.nyu.edu/doku.php?id=deeplearning2015:schedule][DS-GA 1008 - Deep Learning, New York University]]
+    - [ ] [[http://openclassroom.stanford.edu/MainFolder/CoursePage.php?course=DeepLearning][Deep Learning, Stanford University]]
+    - [ ] [[https://uwaterloo.ca/data-science/deep-learning][Deep Learning - University of Waterloo]]
+  - [ ] *Advanced Machine Learning* [0/3]
+    - [ ][[https://www.youtube.com/playlist?list=PLE6Wd9FR--EdyJ5lbFl8UuGjecvVw66F6][ Machine Learning 2013 - Nando de Freitas, UBC]]
+    - [ ] [[https://www.cs.ox.ac.uk/people/nando.defreitas/machinelearning/][Machine Learning: 2014-2015, University of Oxford]]
+    - [ ] [[http://www.stat.cmu.edu/~larry/=sml/][10-702/36-702 - Statistical Machine Learning - Larry Wasserman, Spring 2016, CMU]] ([[https://www.youtube.com/playlist?list=PLjbUi5mgii6BWEUZf7He6nowWvGne_Y8r][Spring 2015]])
+    - [ ] [[http://www.cs.cmu.edu/~bapoczos/Classes/ML10715_2015Fall/][10-715 Advanced Introduction to Machine Learning - CMU]] ([[https://www.youtube.com/playlist?list=PL4DwY1suLMkcu-wytRDbvBNmx57CdQ2pJ][YouTube]])
+  - [ ] *Natural Language Processing and Computer Vision* [0/6]
+    - [ ] [[http://cs224d.stanford.edu/syllabus.html][CS 224d - Deep Learning for Natural Language Processing, Stanford University]] ([[https://www.youtube.com/playlist?list=PLCJlDcMjVoEdtem5GaohTC1o9HTTFtK7_][Lectures - Youtube]])
+    - [ ] [[https://www.youtube.com/playlist?list=PLgtM85Maly3n2Fp1gJVvqb0bTC39CPn1N][CS 224N - Natural Language Processing, Stanford University]]
+    - [ ] [[https://www.youtube.com/playlist?list=PL6397E4B26D00A269][MOOC: Natural Language Processing, Dan Jurafsky & Chris Manning - Coursera]]
+    - [ ] [[https://www.youtube.com/playlist?list=PLLssT5z_DsK8BdawOVCCaTCO99Ya58ryR][MOOC - Natural Language Processing - Coursera, University of Michigan]]
+    - [ ] [[https://www.youtube.com/playlist?list=PLLvH2FwAQhnpj1WEB-jHmPuUeQ8mX-XXG][CS 231n - Convolutional Neural Networks for Visual Recognition, Stanford University]]
+    - [ ] [[https://www.youtube.com/playlist?list=PLTBdjV_4f-EIiongKlS9OKrBEp8QR47Wl][Machine Learning for Computer Vision - TUM]]
+  - [ ] *Misc Machine Learning Topics* [/]
+    - [ ] [[https://www.youtube.com/playlist?list=PLbuogVdPnkCpRvi-qSMCdOwyn4UYoPxTI][CS 6955 - Clustering, Spring 2015, University of Utah]]
+    - [ ] [[http://www.ischool.berkeley.edu/newsandevents/audiovideo/webcast/21963][Info 290 - Analyzing Big Data with Twitter, UC Berkeley school of information]]
+    - [ ] [[http://www.stat.cmu.edu/~ryantibs/convexopt-S15/][10-725 Convex Optimization: Spring 2015 - CMU]]
+    - [ ] [[https://www.youtube.com/playlist?list=PLjTcdlvIS6cjdA8WVXNIk56X_SjICxt0d][10-801 Advanced Optimization and Randomized Algorithms]]
+    - [ ] [[http://people.seas.harvard.edu/~minilek/cs229r/fall15/lec.html][CS 229r - Algorithms for Big Data, Harvard University]] ([[https://www.youtube.com/playlist?list=PL2SOU6wwxB0v1kQTpqpuu5kEJo2i-iUyf][Youtube]])
+    - [ ] [[http://granite.ices.utexas.edu/coursewiki/index.php/Main_Page][CAM 383M - Statistical and Discrete Methods for Scientific Computing, University of Texas]]
+    - [ ] [[https://uwaterloo.ca/data-science/statistical-learning-classification][Statistical Learning- Classification - University of Waterloo]]
+    - [ ] [[https://www.youtube.com/playlist?list=PLyGKBDfnk-iDj3FBd0Avr_dLbrU8VG73O][9.520 - Statistical Learning Theory and Applications, Fall 2015 - MIT]]
+    - [ ] [[https://www.youtube.com/playlist?list=PLacBNHqv7n9gp9cBMrA6oDbzz_8JqhSKo][Reinforcement Learning - UCL]]
+
+| ### Concurrency - [[http://courses.cs.washington.edu/courses/csep506/11sp/Home.html][CSE P 506 -- Concurrency (Spring 2011) University of Washington]] ([[http://courses.cs.washington.edu/courses/csep506/11sp/Videos.html][Videos]]) - [[http://courses.cs.washington.edu/courses/csep524/10sp/][CSEP 524 - Parallel Computation - University of Washington]] ([[http://courses.cs.washington.edu/courses/csep524/10sp/lectures/video.html][Videos]]) - [[https://www.youtube.com/playlist?list=PLZ9NgFYEMxp4KSJPUyaQCj7x--NQ6kvcX][CS 282 (2014): Concurrent Java Network Programming in Android]] - [[https://electures.informatik.uni-freiburg.de/portal/web/guest/detail/-/modulnavigation/view/3303/12101/][Concurrency Theory and Practice - WS 2010 - Universität Freiburg]]   |
+
+*** Computer Networks [0/13]
+  - [ ] [[https://www.ecse.rpi.edu/homepages/koushik/shivkuma-teaching/video_index.html][Prof. Shiv Kalyanaraman's Online Audio and Video Lectures on Computer Networking]]
+  - [ ] [[http://www.cse.wustl.edu/~jain/videos.htm][Audio/Video Recordings and Podcasts of Professor Raj Jain's Lectures - Washington University in St. Louis]] ([[https://www.youtube.com/user/ProfRajJain/playlists][YouTube]])
+  - [ ] [[http://media.pearsoncmg.com/ph/streaming/esm/tanenbaum5e_videonotes/tanenbaum_videoNotes.html][Computer Networks, Tanenbaum, Wetherall Computer Networks 5e - Video Lectures]] ([[https://www.youtube.com/playlist?list=PLkHsKoi6eZnzJl1qTzmvBwTxrSJW4D2Jj][U Washington MOOC]])
+  - [ ] [[http://courses.cs.washington.edu/courses/csep561/13au/][CSEP 561: PMP Network Systems, Fall 2013 - University of Washington]] ([[http://courses.cs.washington.edu/courses/csep561/13au/video/][Videos]])
+  - [ ] [[http://courses.cs.washington.edu/courses/csep561/08au/][CSEP 561 -- Network Systems, Autumn 2008 - University of Washington]] ([[http://courses.cs.washington.edu/courses/csep561/08au/lectures/][Videos]])
+  - [ ] [[https://www.youtube.com/playlist?list=PLvifRcqOOwF8u4iC7hFTMVC_WD6SEpnkx][Introduction to Data Communications 2013, Steven Gordon - Thammasat University, Thailand]]
+  - [ ] [[https://electures.informatik.uni-freiburg.de/portal/web/guest/detail/-/modulnavigation/view/16/2825/][Communication Systems - SS 2008 - Universität Freiburg]]
+  - [ ] [[https://electures.informatik.uni-freiburg.de/portal/web/guest/detail/-/modulnavigation/view/3003/10016/][Communication Systems (Telecommunication from ISDN/GSM to VoIP) - WS 2010 - Universität Freiburg]]
+  - [ ] [[https://electures.informatik.uni-freiburg.de/portal/web/guest/detail/-/modulnavigation/view/73/2764/][Internetworking - SS 2005 - Universität Freiburg]]
+  - [ ] [[https://electures.informatik.uni-freiburg.de/portal/web/guest/detail/-/modulnavigation/view/82/2991/][Mobile Computing - WS 2004 - Universität Freiburg]]
+  - [ ] [[https://electures.informatik.uni-freiburg.de/portal/web/guest/detail/-/modulnavigation/view/5103/15465/][Network Algorithms - SS 2013 - Universität Freiburg]]
+  - [ ] [[https://electures.informatik.uni-freiburg.de/portal/web/guest/detail/-/modulnavigation/view/4509/13493/][Telecommunication Systems - SS 2012 - Universität Freiburg]]
+  - [ ] [[https://electures.informatik.uni-freiburg.de/portal/web/guest/detail/-/modulnavigation/view/112/4172/][Wireless Sensor Networks - WS 2006 (English) - Universität Freiburg]]
+
+--------------
+
+*** Mobile Applications Development [0/5]
+  - [ ] [[https://www.youtube.com/playlist?list=PLkHsKoi6eZnwilGXUc95CqS7Vw4uLLDLG][MOOC Programming Mobile Applications for Android Handheld Systems - University of Maryland]]
+  - [ ] [[https://itunes.apple.com/us/course/developing-ios-7-apps-for/id733644550][CS 193p - Developing Applications for iOS, Stanford University]]
+  - [ ] [[http://cs76.tv/2013/summer/][CS S-76 Building Mobile Applications - Harvard]]
+  - [ ] [[https://www.youtube.com/playlist?list=PLF3EEB647F6B52F03][CSSE490 Android Development Rose-Hulman Winter 2010-2011, Dave Fisher]]
+  - [ ] [[https://www.youtube.com/playlist?list=PL96C635E4DCD393A8][iOS Course, Dave Fisher]]
+
+--------------
+
+*** Math for Computer Scientist [0/14]
+  - [ ] [[https://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-042j-mathematics-for-computer-science-fall-2010/video-lectures/][6.042J - Mathematics for Computer Science, Fall 2010, MIT OCW]]
+  - [ ] [[https://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-042j-mathematics-for-computer-science-spring-2015/index.htm][6.042J - Mathematics for Computer Science, Spring 15, MIT OCW]]
+  - [ ] [[https://www.youtube.com/playlist?list=PL1A2EBAC4283FE3EA][Computer Science 70, 001 - Fall 2012]]
+  - [ ] [[https://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-041sc-probabilistic-systems-analysis-and-applied-probability-fall-2013/][6.041 Probabilistic Systems Analysis and Applied Probability - MIT OCW]]
+  - [ ] [[https://www.youtube.com/playlist?list=PL7y-1rk2cCsA339crwXMWUaBRuLBvPBCg][10-600 Math Background for ML - CMU]]
+  - [ ] [[http://www.cs.cmu.edu/~zkolter/course/linalg/outline.html][Linear Algebra Review - CMU]]
+  - [ ] [[https://www.youtube.com/playlist?list=PL2SOU6wwxB0uwwH80KTQ6ht66KWxbzTIo][Statistics 110: Probability]]
+  - [ ] [[https://ocw.mit.edu/courses/mathematics/18-06sc-linear-algebra-fall-2011/][18.06 - Linear Algebra, Prof. Gilbert Strang, MIT OCW]]
+  - [ ] [[http://www.stat.cmu.edu/~larry/=stat705/][36-705 - Intermediate Statistics - Larry Wasserman, CMU]]
+  - [ ] [[https://www.youtube.com/playlist?list=PL432AB57AF9F43D4F][STATS 250 - Introduction to Statistics and Data Analysis, UMichigan]]
+  - [ ] [[https://www.youtube.com/playlist?list=PLqOZ6FD_RQ7k-j-86QUC2_0nEu0QOP-Wy][131B - Introduction to Probability and Statistics, UCI]]
+  - [ ] [[https://www.youtube.com/playlist?list=PLTBdjV_4f-EJn6udZ34tht9EVIW7lbeo4][Multiple View Geometry - Lecture 1 (Prof. Daniel Cremers) TUM]]
+  - [ ] [[https://www.youtube.com/playlist?list=PLLssT5z_DsK_WYzNXVjT695FdxRxvlSF8][The Probability and Statistics Full Course - YouTube]]
+  - [ ] [[https://www.youtube.com/playlist?list=PL44B6B54CBF6A72DF][A first course in Linear Algebra - N J Wildberger - UNSW]]
+
+--------------
+
+*** Web Programming and Internet Technologies [0/8]
+  - [ ] [[http://cs75.tv/2012/summer/][CS 75 Building Dynamic Websites - Harvard University]]
+  - [ ] [[https://electures.informatik.uni-freiburg.de/portal/web/guest/detail/-/modulnavigation/view/110/423/][Web Search - SS 2006 - Universität Freiburg]]
+  - [ ] [[http://courses.cs.washington.edu/courses/csep545/12wi/][CSEP545: Transaction Processing for E-Commerce, Winter 2012 - University of Washington]] ([[http://courses.cs.washington.edu/courses/csep545/12wi/video/][Videos]])
+  - [ ] [[https://www.cs.colostate.edu/~ct310/yr2016sp/home_progress.php][CT 310 Web Development - Colorado State University]]
+  - [ ] [[https://www.youtube.com/playlist?list=PLvifRcqOOwF9cfLMTE-42fiBsWvBsOEkS][Internet Technologies and Applications 2012, Steven Gordon - Thammasat University, Thailand]]
+  - [ ] [[https://itunes.apple.com/WebObjects/MZStore.woa/wa/viewPodcast?id=454017618][CSCI 3110 Advanced Topics in Web Development, Fall 2011 - ETSU iTunes]]
+  - [ ] [[https://itunes.apple.com/us/itunes-u/e-commerce-implementation/id1020427670][CSCI 5710 e-Commerce Implementation, Fall 2015 - ETSU iTunes]]
+  - [ ] [[https://electures.informatik.uni-freiburg.de/portal/web/guest/detail/-/modulnavigation/view/114/4215/][XML and Semantic Web-Technologies - SS 2005 - Universität Freiburg]]
+
+--------------
+
+*** Theoretical CS and Programming Languages [0/12]
+  - [ ] [[https://www.youtube.com/playlist?list=PLkHsKoi6eZnyEj2pz3R_ER7izlenSxP-I][MOOC - Compilers - Stanford University]]
+  - [ ] [[https://sites.google.com/a/bodik.org/cs164/home][CS 164 Hack your language, UC Berkeley]] ([[https://www.youtube.com/playlist?list=PL3A16CFC42CA6EF4F][Lectures - Youtube]])
+  - [ ] [[http://cs.brown.edu/courses/cs173/2012/Videos/][CS 173 Programming Languages, Brown University]] ([[http://cs.brown.edu/courses/cs173/2012/book/][Book]])
+  - [ ] [[https://courses.engr.illinois.edu/cs421/fa2014/][CS 421 - Programming Languages and Compilers, UIUC]] ([[http://recordings.engineering.illinois.edu/ess/portal/section/631edaeb-2a33-4537-b7c8-0c1cba783a4f][Videos]])
+  - [ ] [[http://pgbovine.net/cpython-internals.htm][CSC 253 - CPython internals: A ten-hour codewalk through the Python interpreter source code, University of Rochester]]
+  - [ ] [[http://courses.cs.washington.edu/courses/csep501/09au/lectures/video.html][CSEP 501 - Compiler Construction, University of Washington]] ([[https://www.youtube.com/playlist?list=PLTPQEx-31JXhfAWGnGzwbfhB2zUB7Jd4C][Lectures - Youtube]])
+  - [ ] [[http://courses.cs.washington.edu/courses/csep505/15wi/video/][CSEP 505 Programming Languages, Winter 2015 - University of Washington]]
+  - [ ] [[http://cs.wheaton.edu/~tvandrun/dmfp/][DMFP - Discrete Mathematics and Functional Programming, Wheaton College]]
+  - [ ] [[https://courses.engr.illinois.edu/cs498374/fa2014/][CS 374 - Algorithms & Models of Computation (Fall 2014), UIUC]] ([[http://recordings.engineering.illinois.edu/ess/portal/section/115f3def-7371-4e98-b72f-6efe53771b2a][Lecture videos]])
+  - [ ] [[https://stellar.mit.edu/S/course/6/sp15/6.045/materials.html][6.045 Automata, Computability, and Complexity, MIT]] ([[http://stellar.mit.edu/S/course/6/sp15/6.045/special/videos/index.html][Lecture Videos]])
+  - [ ] [[http://web.cecs.pdx.edu/~harry/videos/][CS581 Theory of Computation - Portland State University]] ([[https://www.youtube.com/playlist?list=PLbtzT1TYeoMjNOGEiaRmm_vMIwUAidnQz][Lectures - Youtube]])
+  - [ ] [[https://www.youtube.com/playlist?list=PLslgisHe5tBM8UTCt1f66oMkpmjCblzkt][Theory of Computation - Fall 2011 UC Davis]]
+
+--------------
+
+*** Computer Organization and Architecture [0/15]
+  - [ ] [[http://aduni.org/courses/hcw/index.php?view=cw][How Computers Work - Aduni]]
+  - [ ] [[https://www.youtube.com/playlist?list=PLrRW1w6CGAcXbMtDFj205vALOGmiRc82-][6.004 - Computation Structures Spring 2013, MIT]]
+  - [ ] [[http://www-inst.eecs.berkeley.edu/~cs61c/sp15/][CS 61C - Machine Structures, UC Berkeley]] ([[https://www.youtube.com/playlist?list=PL-XXv-cvA_iCl2-D-FS5mk0jFF6cYSJs_][Lectures - YouTube]])
+  - [ ] [[https://www.youtube.com/playlist?list=PL6B940F08B9773B9F][CS1: Higher Computing - Richard Buckland UNSW]]
+  - [ ] [[http://www.ece.cmu.edu/~ece447/s14/doku.php?id=schedule][18-447 - Introduction to Computer Architecture, CMU]] ([[https://www.youtube.com/playlist?list=PL5PHm2jkkXmgVhh8CHAu9N76TShJqfYDt][Lecture - YouTube - Fall 15]])
+  - [ ] [[https://www.youtube.com/playlist?list=PLkFD6_40KJIwEiwQx1dACXwh-2Fuo32qr][CS 152 Computer Architecture and Engineering, UC Berkeley]]
+  - [ ] [[http://courses.cs.washington.edu/courses/csep548/12au/video/index.html][CSEP 548 - Computer Architecture Autumn 2012 - University of Washington]]
+  - [ ] [[http://15418.courses.cs.cmu.edu/spring2015/][15-418 - Parallel Computer Architecture and Programming, CMU]] ([[https://scs.hosted.panopto.com/Panopto/Pages/Sessions/List.aspx#folderID=%22a5862643-2416-49ef-b46b-13465d1b6df0%22][Lecture Videos]])
+  - [ ] [[https://www.youtube.com/playlist?list=PLyg2vmIzGxXGBxFu8nvX3KBadSdsNAvbA][EE445L Embedded Systems Design Lab, Fall 2015, UTexas]]
+  - [ ] [[https://www.youtube.com/playlist?list=PL-XXv-cvA_iDq3FCoYLeUL-X-NUlT405n][CS149 Embedded Systems - Fall 2014 - UCBerkeley]]
+  - [ ] [[http://people.ece.cornell.edu/land/courses/ece4760/][ECE 4760 Designing with Microcontrollers Fall 2016, Cornell University]] ([[https://www.youtube.com/playlist?list=PLKcjQ_UFkrd4I5WOIxHEYZ7iY04lj15Ez][Lectures - Youtube]])
+  - [ ] [[https://people.eecs.berkeley.edu/~demmel/cs267_Spr16/][CS 267 Applications of Parallel Computers, Spring 16 - UC Berkeley]] ([[https://www.youtube.com/playlist?list=PLkFD6_40KJIzSfxr35ZT59-LZcibZmfp2][YouTube]])
+  - [ ] [[https://classes.soe.ucsc.edu/cmpe118/Fall15/][CMPE 118/L(218/L) - Mechatronics - Fall 2015]]
+  - [ ] [[https://itunes.apple.com/us/itunes-u/software-engineering-for-embedded/id429175114][Software Engineering for Embedded Systems - WS 2010/11 - iTunes - HPI]]
+  - [ ] [[https://www.youtube.com/playlist?list=PLB52B8F4E464CEEF7][ELEC2141 Digital Circuit Design, UNSW]]
+
+--------------
+
+*** Security [0/8]
+  - [ ] [[https://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-858-computer-systems-security-fall-2014/video-lectures/][6.858 Computer Systems Security - MIT OCW]]
+  - [ ] [[http://courses.cs.washington.edu/courses/csep590a/11wi/][CSEP590A: Practical Aspects of Modern Cryptography, Winter 2011 - University of Washington]] ([[http://courses.cs.washington.edu/courses/csep590a/11wi/video/][Videos]])
+  - [ ] [[http://www.cs.fsu.edu/~redwood/OffensiveComputerSecurity/lectures.html][CIS 4930/ CIS 5930 - Offensive Computer Security, Florida State University]]
+  - [ ] [[https://courseware.stanford.edu/pg/courses/334553/18636-spring-2013][18-636 Browser Security, Stanford]]
+  - [ ] [[https://www.tele-task.de/archive/series/overview/1084/][Internet Security - Weaknesses and Targets (WT 2015/16)]] ([[https://www.tele-task.de/archive/series/overview/921/][WT 2012/13]] ([[https://www.youtube.com/playlist?list=PLVWVhkyKd-7taP50fB9PeZ2W_EPTOLD8o][YouTube]]))
+  - [ ] [[https://www.youtube.com/playlist?list=PLvifRcqOOwF9-XSGfm-3uA9DfF7plasCF][IT Security, Steven Gordon - Thammasat University, Thailand]]
+  - [ ] [[https://www.youtube.com/playlist?list=PLvifRcqOOwF-z2sfMb3w0uQzd7PfaLFlU][Security and Cryptography, Steven Gordon - Thammasat University, Thailand]]
+  - [ ] [[https://electures.informatik.uni-freiburg.de/portal/web/guest/detail/-/modulnavigation/view/111/4163/][Web Security - SS 2008 - Universität Freiburg]]
+
+--------------
+
+*** Computer Graphics [0/5]
+  - [ ] [[http://dataviscourse.net/2016/index.html][CS 5630/6630 - Visualization, Fall 2016, University of Utah]] ([[https://www.youtube.com/playlist?list=PLbuogVdPnkCpQY3miQpTJtnHgCLze2lr0][Lectures - Youtube]])
+  - [ ] [[https://www.youtube.com/playlist?list=PLslgisHe5tBNnySlj9TlL-n-4jNEK-xgi][Advanced Visualization UC Davis]]
+  - [ ] [[https://www.youtube.com/playlist?list=PL9C949E9F19381E61][Computer Graphics Fall 2011]]
+  - [ ] [[https://www.youtube.com/playlist?list=PL4A8BA1C3B38CFCA0][Introduction to Graphics Architecture]]
+  - [ ] [[http://inst.eecs.berkeley.edu/~cs184/fa12/onlinelectures.html][CS184 Computer Graphics, Fall 2012 - UC Berkeley]]
+
+--------------
+
+*** Image Processing and Computer Vision [0/8]
+  - [ ] [[https://inst.eecs.berkeley.edu/~ee225b/sp14/][EE225B Digital Image Processing, Spring 2014 - UC Berkeley]] ([[http://www-video.eecs.berkeley.edu/~avz/video_225b.html][Videos - Spring 2006]])
+  - [ ] [[https://engineering.purdue.edu/~bouman/ece637/][EE637: Digital Image Processing I - Purdue University]] ([[https://www.youtube.com/user/ModelBasedImaging][Videos - Sp 2011]],[[https://engineering.purdue.edu/~bouman/ece637/lectures/lectures07/][Videos - Sp 2007]])
+  - [ ] [[https://www.youtube.com/playlist?list=PLA64AFAE28B8DD0FD][Image Processing and Analysis UC Davis]]
+  - [ ] [[http://crcv.ucf.edu/courses/CAP5415/Fall2014/index.php][CAP 5415 - Computer Vision, University of Central Florida]]
+  - [ ] [[https://www.youtube.com/playlist?list=PLTBdjV_4f-EJ7A2iIH5L5ztqqrWYjP2RI][Lecture: Variational Methods for Computer Vision (Prof. D. Cremers) TUM]]
+  - [ ] [[https://www.youtube.com/playlist?list=PLA64AFAE28B8DD0FD][Image Processing and Analysis (Course) UC Davis]]
+  - [ ] [[http://groups.inf.ed.ac.uk/vision/VIDEO/2015/ivr.htm][Introduction to Vision and Robotics]]
+  - [ ] [[http://inside.mines.edu/~whoff/courses/EENG512/lectures/][EENG 512 / CSCI 512 - Computer Vision - Colorado School of Mines]]
+
+| ### HCI - [[http://hci.stanford.edu/courses/cs147/2015/au/calendar.php][CS147: Introduction to Human-Computer Interaction Design - Stanford]] - [[http://courses.cs.washington.edu/courses/csep510/04wi/][CSEP 510: Human Computer Interaction]] - [[https://www.youtube.com/playlist?list=PL9444191613E018CC][Programming for Designers - COMP1400-T2 (2010) - UNSW]]   |
+
+*** Computational Biology [0/3]
+  - [ ] [[http://www.algorist.com/computational_biology/][Skiena's Computational Biology Lectures]]
+  - [ ] [[https://ocw.mit.edu/courses/biology/7-91j-foundations-of-computational-and-systems-biology-spring-2014/video-lectures/][6.802J/ 6.874J Foundations of Computational and Systems Biology - MIT OCW]]
+  - [ ] [[https://electures.informatik.uni-freiburg.de/portal/web/guest/detail/-/modulnavigation/view/3013/10069/][Bioinformatic II - WS 2010 - Universität Freiburg]]
+
+--------------
+
+*** Misc [0/12]
+  - [ ] [[http://www.algorist.com/computational_finance/index.html][Skiena's Computational Finance Lectures]]
+  - [ ] [[http://am207.github.io/2016/index.html][AM 207 - Monte Carlo Methods and Stochastic Optimization, Harvard University]]
+  - [ ] [[http://see.stanford.edu/see/courseinfo.aspx?coll=86cc8662-f6e4-43c3-a1be-b30d1d179743][CS 223A - Introduction to Robotics, Stanford University]]
+  - [ ] [[http://www.cs.cornell.edu/courses/CS3152/2014sp/lectures/index.php][CS 3152 - Introduction to Computer Game Development, Cornell University]]
+  - [ ] [[http://www.schneems.com/ut-rails/][Open Sourced Elective: Database and Rails - Intro to Ruby on Rails, University of Texas]] ([[https://www.youtube.com/playlist?list=PL7A85FD7803A8CB1F][Lectures - Youtube]])
+  - [ ] [[http://mlecture.uni-bremen.de/ml/index.php?option=com_content&view=article&id=233][SCICOMP - An Introduction to Efficient Scientific Computation, Universität Bremen]] ([[https://www.youtube.com/user/fillwithlight/videos][Lectures - Youtube]])
+  - [ ] [[https://ocw.mit.edu/courses/comparative-media-studies-writing/cms-611j-creating-video-games-fall-2014/lecture-videos/][MIT CMS.611J Creating Video Games, Fall 2014]]
+  - [ ] [[https://www.youtube.com/playlist?list=PLTBdjV_4f-EKeki5ps2WHqJqyQvxls4ha][Lecture: Visual Navigation for Flying Robots - TUM]]
+  - [ ] [[http://cs259.tv/2007/fall/][CS E-259 XML with Java, Java Servlet, and JSP - Harvard]]
+  - [ ] [[https://www.youtube.com/view_play_list?p=0105F1427EFAEE0A][CSE 40373 - Spr 2009: Multimedia Systems]]
+  - [ ] [[http://tv.digitalphotography.exposed/2010/fall/][Exposing Digital Photography - Harvard Extension School]]
+  - [ ] [[https://electures.informatik.uni-freiburg.de/portal/web/guest/detail/-/modulnavigation/view/4006/12519/][XML and Databases - WS 2011 - Universität Freiburg]]
+
+--------------
+
+-  Additional Information
+
+   -  Disclaimer: The links have been taken from public domain websites
+      like Open courseware sites, class-central, , YouTube channels for
+      Universities, University pages, Google, itunes U, blog posts and
+      similar sites like awesome-courses etc. If you are University
+      Professor for any course listed below and would like Your course
+      to be removed from the list, please raise an issue with course
+      details.
+
+--------------


### PR DESCRIPTION
I don't know if this is something you'd like to merge, for org-mode users it's a really nice way to organize links like these though.
