### PR TITLE
Add c4cs to miscellaneous courses

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,7 @@ Courses
 - [XML and Databases - WS 2011 - Universität Freiburg](https://electures.informatik.uni-freiburg.de/portal/web/guest/detail/-/modulnavigation/view/4006/12519/)
 - [Unity3D Tutorials](https://www.youtube.com/playlist?list=PL5FMIyKmleRwYdMIuejPS5csShp237A3X)
 - [MOOC: Matlab - Coursera](https://www.youtube.com/playlist?list=PLcKDPPOF93EvvBrgR852MU13zvS2ihTpR)
+- [Computing for Computer Scientists - University of Michigan](https://c4cs.github.io)
 
 -------------------------
 


### PR DESCRIPTION
Computing for Computer Scientists is a 1 credit seminar at University of Michigan designed to teach the essentials of using a computer effectively for CS students.