### PR TITLE
Updated Stanford Compilers link

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,7 +488,7 @@ Courses
 ### Theoretical CS and Programming Languages
 
 
-- [MOOC - Compilers - Stanford University](https://www.youtube.com/playlist?list=PL34iyE0uXtxrgPZMv0dVmq1P8Io889oWZ)
+- [MOOC - Compilers - Stanford University](https://lagunita.stanford.edu/courses/Engineering/Compilers/Fall2014/info)
 - [CS 164 Hack your language, UC Berkeley](https://sites.google.com/a/bodik.org/cs164/home) ([Lectures - Youtube](https://www.youtube.com/playlist?list=PL3A16CFC42CA6EF4F))
 - [CS 173 Programming Languages, Brown University](http://cs.brown.edu/courses/cs173/2012/Videos/) ([Book](http://cs.brown.edu/courses/cs173/2012/book/))
 - [CS 421 - Programming Languages and Compilers, UIUC](https://courses.engr.illinois.edu/cs421/fa2014/) ([Videos](http://recordings.engineering.illinois.edu/ess/portal/section/631edaeb-2a33-4537-b7c8-0c1cba783a4f))


### PR DESCRIPTION
Content from Youtube has been removed so I linked it to the Stanford MOOC page.