### PR TITLE
Fix broken link for [Introduction to Machine Learning for Coders] in …

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Table of Contents
 
 - **Introduction to Machine Learning**
   - [MOOC Machine Learning Andrew Ng - Coursera/Stanford](https://www.youtube.com/playlist?list=PLLssT5z_DsK-h9vYZkQkYNWcItqhlRJLN) ([Notes](http://www.holehouse.org/mlclass/))
-  - [Introduction to Machine Learning for Coders](https://course.fast.ai/ml.html)
+  - [Introduction to Machine Learning for Coders](https://course18.fast.ai/ml)
   - [MOOC - Statistical Learning, Stanford University](http://www.dataschool.io/15-hours-of-expert-machine-learning-videos/)
   - [Foundations of Machine Learning Boot Camp, Berkeley Simons Institute](https://www.youtube.com/playlist?list=PLgKuh-lKre11GbZWneln-VZDLHyejO7YD)
   - [CS155 - Machine Learning & Data Mining, 2017 - Caltech](https://www.youtube.com/playlist?list=PLuz4CTPOUNi6BfMrltePqMAHdl5W33-bC) ([Notes](http://www.yisongyue.com/courses/cs155/2017_winter/)) ([2016](https://www.youtube.com/playlist?list=PL5HdMttxBY0BVTP9y7qQtzTgmcjQ3P0mb))


### PR DESCRIPTION
…Machine Problem

https://course.fast.ai/ml.html no longer works and takes you to a broken github page. https://course18.fast.ai/ml is the new link