### PR TITLE
Add Statistical Learning Theory course from KAIST

### DIFF
--- a/README.md
+++ b/README.md
@@ -803,6 +803,7 @@ Table of Contents
   - [Info 290 - Analyzing Big Data with Twitter, UC Berkeley school of information](http://blogs.ischool.berkeley.edu/i290-abdt-s12/) ([YouTube](https://www.youtube.com/playlist?list=PLE8C1256A28C1487F))
   - [CS224W Machine Learning with Graphs | Spring 2021 | Stanford University](https://www.youtube.com/playlist?list=PLoROMvodv4rPLKxIpqhjhPgdQy7imNkDn)
   - [9.520 - Statistical Learning Theory and Applications, Fall 2015 - MIT](https://www.youtube.com/playlist?list=PLyGKBDfnk-iDj3FBd0Avr_dLbrU8VG73O)
+  - [EE531 - Statistical Learning Theory, Spring 2026 - KAIST](https://www.youtube.com/playlist?list=PL7ToDS7cyORV5XtQ_Kkj07yp_3BnNouWK)
   - [Statistical Learning Theory, Spring 2019 - ETH Zürich](https://video.ethz.ch/lectures/d-infk/2019/spring/252-0526-00L.html)
   - [Course on the Statistical Learning Theory, University of São Paulo, ICMC](https://www.youtube.com/playlist?list=PLKWX1jIoUZaVpVhMfevAE7iYNcDHPEJI_)
   - [Reinforcement Learning - UCL](https://www.youtube.com/playlist?list=PLacBNHqv7n9gp9cBMrA6oDbzz_8JqhSKo)


### PR DESCRIPTION
Statistical Learning Theory course taught by Chang Dong Yoo from KAIST.

* [Course playlist](https://www.youtube.com/playlist?list=PL7ToDS7cyORV5XtQ_Kkj07yp_3BnNouWK)