### PR TITLE
Add Machine Learning for 3D Data course from KAIST

### DIFF
--- a/README.md
+++ b/README.md
@@ -832,6 +832,7 @@ Table of Contents
   - [Statistical Physics of Machine Learning](https://www.youtube.com/playlist?list=PL04QVxpjcnjgzMr9ehyZUSkwu0Wr0cF_N)
   - [11-755 - Machine Learning for Signal Processing, CMU](https://cmu-mlsp.github.io/mlspcourse/schedule/) ([YouTube-2024](https://www.youtube.com/playlist?list=PLWhigAi1mTpO3Rw-1D2b2AowYeIU5eRzD), [YouTube-2023](https://www.youtube.com/playlist?list=PLWhigAi1mTpPMV3hECmkEv3s8Lc8H_VUd))
   - [Machine Learning for 3D Data, Fall 2023, KAIST](https://mhsung.github.io/kaist-cs479-fall-2023/)
+  - [Machine Learning for 3D Data, Spring 2026, KAIST](https://3dml.kaist.ac.kr/) [Recordings](https://www.youtube.com/playlist?list=PLyi5FHzX7hBxJnkFZa-9oVZnTsQcux79M)
   - [Machine Learning for Physicists, Spring 2019, FAU](https://www.fau.tv/course/id/778) ([Spring 2017](https://www.fau.tv/course/id/574))
   - [CSCE 585 - Machine Learning Systems, University of South Carolina](https://pooyanjamshidi.github.io/mls/lectures/) ([YouTube-2020](https://www.youtube.com/playlist?list=PLtkQf9LiEmLFS56WTpRJ3PZwwCYyi2Cdu))
   - [CS-E4740 - Federated Learning, Spring 2023, Aalto University](https://www.youtube.com/playlist?list=PLrbn2dGrLJK8c6hCQXBVFoYsPXG-g_75c)


### PR DESCRIPTION
Machine Learning for 3D Data course (Spring 2026) taught by Minhyuk Sung from KAIST.

* [Course website](https://3dml.kaist.ac.kr/)
* [Course playlist](https://www.youtube.com/playlist?list=PLyi5FHzX7hBxJnkFZa-9oVZnTsQcux79M)