### PR TITLE
Add Applied Electromagnetic Theory course from UCB

### DIFF
--- a/README.md
+++ b/README.md
@@ -1344,6 +1344,7 @@ Table of Contents
 - [Computational Astrophysics - AstroTwinCoLo, 2015](https://www.youtube.com/playlist?list=PLPdkBLbDPtqoHDcjUweIJqe6GKnOz0-Qw)
 - [Astroinformatics 2019 Conference - Caltech](https://m.youtube.com/playlist?list=PL8_xPU5epJdcv2L4MzpzNd6gPyq6glmjc)
 - [Space Science with Python - Astroniz](https://www.youtube.com/playlist?list=PLNvIBWkEdZ2iCc8G9dvx6MQvBruJG-TE8)
+- [EE 210 Applied Electromagnetic Theory, UC Berkeley](https://adityamuppala.github.io/teaching210/) [Videos - Fa 2025](https://www.youtube.com/playlist?list=PL9Trid0A4Da1E9O0tWe9XYMTeuAcexVcp)
 - [Computational Physics Course in Python, Rutgers 2021](https://www.youtube.com/playlist?list=PLXmUYdQdC9IGv61Y1lhGBH0NsDQRdwcJE)
 - [Landau Computational Physics Course](https://www.youtube.com/playlist?list=PLnWQ_pnPVzmJnp794rQXIcwJIjwy7Nb2U)
 - [Statistical Methods and Machine Learning in High Energy Physics](https://www.youtube.com/playlist?list=PL04QVxpjcnjjKDki5FHlKQ8839TGHvj8y)


### PR DESCRIPTION
Applied Electromagnetic Theory course (Fall 2025) taught by Aditya Varma Muppala from UC Berkeley.

* [Course website](https://adityamuppala.github.io/teaching210/)
* [Course playlist](https://www.youtube.com/playlist?list=PL9Trid0A4Da1E9O0tWe9XYMTeuAcexVcp)