### PR TITLE
Add Discrete Mathematics course from Georgia Tech

### DIFF
--- a/README.md
+++ b/README.md
@@ -898,6 +898,7 @@ Table of Contents
 - **Discrete Math**
   - [6.042J - Mathematics for Computer Science, MIT OCW](https://ocw.mit.edu/courses/6-042j-mathematics-for-computer-science-fall-2010/video_galleries/video-lectures/) 
   - [18.200 - Principles of Discrete Applied Mathematics, MIT OCW](https://ocw.mit.edu/courses/18-200-principles-of-discrete-applied-mathematics-spring-2024/video_galleries/lecture-videos/)
+  - [CS 2050 Discrete Mathematics, Georgia Tech](https://faculty.cc.gatech.edu/~ladha/discrete/) [Videos - Su 2024](https://www.youtube.com/playlist?list=PLerMEx1Met7tdZvHntzJ731A6amAvs7S8)
   - [UC Berkeley Computer Science 70, Discrete Mathematics and Probability Theory - Fall 2025](https://www.eecs70.org/) ([YouTube](https://www.youtube.com/playlist?list=PLIygTcviGPKDV7TrbTokEDN0haWwiV_xp))
   - [CSE 547 Discrete Mathematics, Prof Skiena, University of Stony Brook](http://www3.cs.stonybrook.edu/~algorith/math-video/)
   - [Discrete Structures (Summer 2011) - Rutgers, The State University of New Jersey](https://itunes.apple.com/us/course/discrete-structures-summer/id698728837)


### PR DESCRIPTION
CS 2050 Discrete Mathematics course taught by [Abrahim Ladha](https://faculty.cc.gatech.edu/~ladha/) from Georgia Tech.

* [Course website](https://faculty.cc.gatech.edu/~ladha/discrete/)
* [Course playlist](https://www.youtube.com/playlist?list=PLerMEx1Met7tdZvHntzJ731A6amAvs7S8)